### PR TITLE
BVHAnimData: fix uninitialized field in constructor

### DIFF
--- a/src/com/jme3/scene/plugins/bvh/BVHAnimData.java
+++ b/src/com/jme3/scene/plugins/bvh/BVHAnimData.java
@@ -41,7 +41,7 @@ public class BVHAnimData {
     private Animation animation;
     private float timePerFrame;
 
-    public BVHAnimData(Skeleton skeleton, Animation anim, float timePerFrames) {
+    public BVHAnimData(Skeleton skeleton, Animation anim, float timePerFrame) {
         this.skeleton = skeleton;
         this.animation = anim;
         this.timePerFrame = timePerFrame;


### PR DESCRIPTION
Due to a typographical error, the constructor for BVHAnimData failed to initialize the "timePerFrame" field.