### PR TITLE
BoneMapping: add no-arg constructor so asset loader will work

### DIFF
--- a/src/com/jme3/scene/plugins/bvh/BoneMapping.java
+++ b/src/com/jme3/scene/plugins/bvh/BoneMapping.java
@@ -37,6 +37,13 @@ public class BoneMapping implements Savable {
     private Quaternion twist;
 
     /**
+     * No-argument constructor for serialization purposes only. Do not invoke
+     * directly!
+     */
+    public BoneMapping() {
+    }
+    
+    /**
      * Builds a BoneMapping witht he given bone from the target skeleton and the
      * given bone from the source skeleton.
      *


### PR DESCRIPTION
In order to load an object from a J3O, the asset loader needs a no-argument constructor for it. Since BoneMapping implements Savable, I assume you intended it to be loadable from a J3O.